### PR TITLE
removing underline from h3<a> tags

### DIFF
--- a/style.css
+++ b/style.css
@@ -176,7 +176,7 @@ body {
 }
 
 /* Documentation Header */
-#docs h2>a, h3>a{
+#docs h2>a, #docs h3>a{
     color: black;
     text-decoration: none;
 }


### PR DESCRIPTION
fixes as mentioned in [#51(comment)](https://github.com/commons-app/commons-app.github.io/pull/51#issuecomment-762512953) .  @nicolas-raoul 