### PR TITLE
Fix typos and change Commons links to use Special:MyLanguage for Commons links

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,8 @@
         <h2>The App</h2>
         <p class="lead">
         The Commons Mobile App is a <a href="https://github.com/commons-app/apps-android-commons">
-        community maintained</a> app that makes it easy to upload your pictures to
-        <a href="https://commons.wikimedia.org/wiki/Commons:Welcome">Wikimedia Commons</a>.
+        community-maintained</a> app that makes it easy to upload your pictures to
+        <a href="https://commons.wikimedia.org/wiki/Special:MyLanguage/Commons:Welcome">Wikimedia Commons</a>.
         The app can be installed on any Android device and uses your Commons user account to upload photos.
         </p>
         <div class="btn-group">
@@ -72,7 +72,7 @@
         </p>
         <a class="btn btn-lg btn-outline-primary"
            role="button"
-           href="https://commons.wikimedia.org/w/index.php?title=Special:UserLogin&returnto=Main+Page">
+           href="https://commons.wikimedia.org/w/index.php?title=Special:UserLogin&returnto=Special:MyLanguage/Main+Page">
            Join Commons
        </a>
     </div>
@@ -262,7 +262,7 @@ Sunset at chunnmbar: Kaartic [CC BY-SA 3.0 (https://creativecommons.org/licenses
             <li class="text-success">✓ Photos that document the world around you</li>
             <li class="text-success">✓ Photos of notable objects that you find in the <strong>Nearby List</strong> in the app.</li>
             <li class="text-danger">✖ Photos of you or your friends. But if you are documenting an event it doesn't matter if they are in the picture.</li>
-            <li class="text-danger">✖ Photos of poor quality. Make sure the things you are trying to document are visible on the picture.</li>
+            <li class="text-danger">✖ Photos of poor quality. Make sure the things you are trying to document are visible in the picture.</li>
         </ul>
     </div>
     <div class="section-divider"></div>


### PR DESCRIPTION
Typos:
community maintained -> community-maintained
on the picture -> in the picture

Use Special:MyLanguage for links because they should be in people's own language even if the Commons App site is only in English