### PR TITLE
Fix Wikidata links in /docs.html

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -45,7 +45,7 @@
         <ol>
             <li>Use a VPN</li>
             <li>Create a throwaway Wikimedia account without an email address, and only use it for that picture or set of pictures. Then afterwards avoid modifying these pictures with your usual account.</li>
-            <li>Remove the EXIF from your picture. Only a few persons on Earth use the same camera model, same firmware version, same settings as you, and all of this information is available in the EXIF, making it easy to link from this picture to your other pictures. The application <a href="https://gitlab.com/juanitobananas/scrambled-exif">Scrambled Exif</a> (<a href="https://f-droid.org/en/packages/com.jarsilio.android.scrambledeggsif/">F-Droid</a> , <a href="https://play.google.com/store/apps/details?id=com.jarsilio.android.scrambledeggsif">Google Play</a> ) makes the process easy.</li>
+            <li>Remove the EXIF from your picture. Only a few persons on Earth use the same camera model, same firmware version, same settings as you, and all of this information is available in the EXIF, making it easy to link from this picture to your other pictures. The application <a href="https://gitlab.com/juanitobananas/scrambled-exif">Scrambled Exif</a> (<a href="https://f-droid.org/packages/com.jarsilio.android.scrambledeggsif/">F-Droid</a> , <a href="https://play.google.com/store/apps/details?id=com.jarsilio.android.scrambledeggsif">Google Play</a> ) makes the process easy.</li>
             <li>Even lens/camera imperfections might theoretically allow a very motivated organization to match your pictures.</li>
         </ol>
 
@@ -55,7 +55,7 @@
         <h3 id="obsolete-items"><a href="#obsolete-items">Obsolete items</a></h3>
         <p><b>Scenario</b>: Yes there used to be a castle here, but now there is absolutely nothing left, maybe it is just green fields or a factory or recent houses. There is not even a plaque indicating that there used to be a castle.</p>
 
-        <p><b>How to fix it</b>: Go to <a href="www.wikidata.org">www.wikidata.org</a> in your browser, and search for the item in the search bar. At the Wikidata item page, click on "Add statement", type "ended" property and select the "ended" property that appears. In the field that appears, enter the date at which the item disappeared, or just set it to "unknown" if you don't know when that happened. Finally, press "Publish".</p>
+        <p><b>How to fix it</b>: Go to <a href="https://www.wikidata.org">www.wikidata.org</a> in your browser, and search for the item in the search bar. At the Wikidata item page, click on "Add statement", type "ended" property and select the "ended" property that appears. In the field that appears, enter the date at which the item disappeared, or just set it to "unknown" if you don't know when that happened. Finally, press "Publish".</p>
 
         <img class="shadow my-2 img-fluid" src="https://upload.wikimedia.org/wikipedia/commons/c/c1/Wikidata_screenshot_-_Add_statement.png" alt="">
         <img class="shadow my-2 img-fluid" src="https://upload.wikimedia.org/wikipedia/commons/5/5c/Wikidata_screenshot_-_select_%22ended%22_property.png" alt="">
@@ -66,7 +66,7 @@
         <h3 id="wrong-coordinates"><a href="#wrong-coordinates">Wrong coordinates</a></h3>
         <p><b>Scenario</b>: The pin shows the "Bodleian Library" here, but actually you know this library it is at a different place, maybe 10 meters across the street or even a few kilometers away. Make sure your GPS is correct, and double-check locations.</p>
 
-        <p><b>How to fix it</b>: Go to <a href="www.wikidata.org">www.wikidata.org</a> in your browser, and search for the item in the search bar. At the Wikidata item page, edit the coordinate location, enter the right location (most latitude/longitude formats are accepted), and remove the reference if there was one. Then go to the talk page and explain why you think this is the real location.</p>
+        <p><b>How to fix it</b>: Go to <a href="https://www.wikidata.org">www.wikidata.org</a> in your browser, and search for the item in the search bar. At the Wikidata item page, edit the coordinate location, enter the right location (most latitude/longitude formats are accepted), and remove the reference if there was one. Then go to the talk page and explain why you think this is the real location.</p>
 
         <h2 id="getting-app-logs-from-android-studio"><a href="#getting-app-logs-from-android-studio">Getting app logs from Android Studio</a></h2>
         <p>Brief walkthrough for users on how to post logs if they are encountering issues.</p>


### PR DESCRIPTION
links without protocols try and go to a file with the same name in that directory, making it go to https://commons-app.github.io/www.wikidata.org instead of htps://www.wikidata.org