### PR TITLE
Add Privacy Policy Section to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
                     <li class="nav-item"><a class="nav-link scroll" href="#usage">Usage</a></li>
                     <li class="nav-item"><a class="nav-link scroll" href="#photo-guide">Photo Guidelines</a></li>
                     <li class="nav-item"><a class="nav-link scroll" href="./docs.html#docs">Documentation</a></li>
+                    <li class="nav-item"><a class="nav-link scroll" href="#privacy-policy">Privacy Policy</a></li>
                     <li class="nav-item "><btn href="#" class="nav-link scroll toggle-theme"></btn>
                 </ul>
             </div> <!-- .collapse -->
@@ -267,6 +268,78 @@ Sunset at chunnmbar: Kaartic [CC BY-SA 3.0 (https://creativecommons.org/licenses
         </ul>
     </div>
     <div class="section-divider"></div>
+    <!-- Privacy Policy Section -->
+<section id="privacy-policy" class="inner container">
+    <h2>Privacy Policy</h2>
+    <p>
+        The Wikimedia Commons Android app is a free, open-source app developed by grantees and volunteers of the Wikimedia community to allow users to upload content to Wikimedia Commons. This APPLICATION is provided by members of the Wikimedia community and is intended for use as is.
+    </p>
+    <p>
+        This Policy is used to inform users regarding our policies with the collection, use, and disclosure of Personal Information. If you choose to use the Wikimedia Commons Android app, then you agree to the collection and use of information in relation with this policy. The Personal Information that we collect are used for providing and improving the Application. We will not use or share your information with anyone except as described in this Privacy Policy, and we do not rent or sell your information to third parties.
+    </p>
+
+    <h3>Information Collection and Use</h3>
+    <p>
+        While using our Application, we may require you to provide us with certain personally identifiable information, including but not limited to your username, location and pictures stored on your phone. Images that you upload to Wikimedia Commons via our Application will be publicly viewable on Wikimedia Commons along with your username, the location of the image (if geotagging is enabled) and associated image data. Aside from that, the information that we request is retained on your device and is not collected by us in any way.
+    </p>
+    <p>
+        The app does use third party services that may collect information used to identify you.
+    </p>
+
+    <h3>Third-party Service Providers</h3>
+    <p>
+        We use Mapbox map servers in order to provide the "Nearby places that need photos" feature in our Application. We want to inform users of this Application that these third parties have access to your Personal Information. However, they are obligated not to disclose or use the information for any other purpose.
+    </p>
+    <p>
+        Mapbox's <a href="https://www.mapbox.com/privacy/#[MDWaYcfm]">privacy policy</a> states that:
+    </p>
+    <blockquote>
+        When a mobile application uses Mapbox SDKs, it may send to Mapbox certain limited location and usage data along with an ephemeral ID. We also use a more stable ID for the limited purpose of tracking the number of monthly active users connected to our developer customers. If we collect location data, we do not associate it with any identifying information, including names, permanent IDs, email addresses, IP addresses, or phone numbers. You can find more information about how we secure and use location data on our telemetry page.
+    </blockquote>
+
+    <h3>Image EXIF Data</h3>
+    <p>
+        Images uploaded to Wikimedia Commons via this Application will NOT be stripped of EXIF metadata that may contain (but is not limited to) image location, date taken, phone manufacturer and model, and camera settings. All of this metadata will be visible on Wikimedia Commons along with the image. If a user desires to strip an image of EXIF metadata, it is recommended that this be done prior to uploading.
+    </p>
+
+    <h3>Log Data</h3>
+    <p>
+        We want to inform you that whenever you use our Application, in case of an error in the app we collect data and information (through third party products) on your phone called Log Data. This Log Data may include information such as your devices’s Internet Protocol (“IP”) address, device name, operating system version, configuration of the app when utilising our Application, the time and date of your use of the Application, and other statistics. This Data can only be viewed on the Google Play Developer console by developers with access to this console.
+    </p>
+
+    <h3>Cookies</h3>
+    <p>
+        Cookies are files with small amount of data that is commonly used an anonymous unique identifier. These are sent to your browser from the website that you visit and are stored on your devices’s internal memory. This Application does not uses these “cookies” explicitly. However, the app may use third party code and libraries that use “cookies” to collection information and to improve their services. You have the option to either accept or refuse these cookies, and know when a cookie is being sent to your device. If you choose to refuse cookies, you may not be able to use some portions of this Application.
+    </p>
+
+    <h3>Security</h3>
+    <p>
+        We value your trust in providing us your Personal Information, thus we are striving to use commercially acceptable means of protecting it. But remember that no method of transmission over the internet, or method of electronic storage is 100% secure and reliable, and we cannot guarantee its absolute security.
+    </p>
+
+    <h3>Links to Other Sites</h3>
+    <p>
+        This Application may contain links to other sites. If you click on a third-party link, you will be directed to that site. Note that these external sites are not operated by us. Therefore, we strongly advise you to review the Privacy Policy of these websites. We have no control over, and assume no responsibility for the content, privacy policies, or practices of any third-party sites or services.
+    </p>
+
+    <h3>Children’s Privacy</h3>
+    <p>
+        We do not knowingly collect personal identifiable information from children under 13. In the case we discover that a child under 13 has provided us with personal information, we immediately delete this from our servers. If you are a parent or guardian and you are aware that your child has provided us with personal information, please contact us so that we will be able to carry out necessary actions.
+    </p>
+
+    <h3>Changes to This Privacy Policy</h3>
+    <p>
+        We may update our Privacy Policy from time to time. Thus, you are advised to review this page periodically for any changes. We will notify you of any changes by posting the new Privacy Policy on this page. These changes are effective immediately, after they are posted on this page.
+    </p>
+
+    <h3>Contact Us</h3>
+    <p>
+        If you have any questions or suggestions about our Privacy Policy, please do not hesitate to contact us by <a href="https://github.com/commons-app/apps-android-commons/issues/new">creating an issue</a> here on GitHub or posting on our <a href="https://groups.google.com/forum/#!forum/commons-app-android">Google Groups forum</a>.
+    </p>
+    <p>
+        This Privacy Policy was adapted from a template from <a href="https://privacypolicytemplate.net/">privacypolicytemplate.net</a>.
+    </p>
+</section>
     <footer class="inner container footer">
         <h2>Commons Mobile App</h2>
         <div class="btn-group">


### PR DESCRIPTION
**Description**
This PR updates the Privacy Policy link in the app and adds the Privacy Policy section to `index.html` to comply with Google Play's requirements.

**Changes**
1. Updated `launchPrivacyPolicy` in `AboutActivity.kt` to point to `https://commons-app.github.io/#privacy-policy`.
2. Added Privacy Policy content from `Privacy-policy.md` to `index.html` as a new section.

**Why These Changes?**
- Google Play requires the Privacy Policy to be hosted on a publicly accessible, non-editable URL.
- The new URL (`https://commons-app.github.io/#privacy-policy`) meets these requirements.

**Testing**
- Verified the Privacy Policy link redirects to the new URL.
- Confirmed the Privacy Policy section displays correctly on GitHub.io.
